### PR TITLE
How to enable drush aliases in order to deploy config to your Acquia Cloud site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ignore script that sets env variables
+set_environment_variables.sh
+
 # Ignore configuration files that may contain sensitive information.
 local.settings.php
 local.drush.yml

--- a/README.md
+++ b/README.md
@@ -134,6 +134,32 @@ http://local.dojportal-blt.com/
 
 If you don't see anything, check your `/etc/hosts` file or adjust the port forwarding settings in your `Vagrantfile`.
 
+## ... I want to run drush commands against Acquia Cloud sites
+
+Copy the example `set_environment_variables` example file over:
+
+```
+cp example.set_environment_variables.sh set_environment_variables.sh
+```
+
+Fill in the environment variables based on your Acquia Cloud config.
+
+Then, execute the file to set the environment variables locally:
+
+```
+chmod +x set_environment_variables.sh
+
+./set_environment_variables.sh
+```
+
+Cheeck to see if your drush aliases are set up correctly:
+
+```
+drush sa
+```
+
+You should see local, dev, and test environments listed.
+
 ## ... I want to set up a new Drupal site
 
 After you've completed steps 1 through 6 above:

--- a/README.md
+++ b/README.md
@@ -220,15 +220,19 @@ blt sync
 
 # Deploy
 
+First, make sure you have run the `set_environment_variables` script, as described above in "I want to run drush commands against Acquia Cloud sites".
+
+Next:
+
 ```
-ACQUIA_CLOUD_REMOTE_GIT=acquia_git_destination blt artifact:deploy --commit-msg "BLT-001: Commit message here." --branch "branch name here" --no-interaction
+blt artifact:deploy --commit-msg "BLT-001: Commit message here." --branch "branch name here" --no-interaction
 ```
 
 Note that by default, commit messages need to conform to a strict pattern specified in `build.yml` under `git > commit-msg > pattern`. The default regex pattern is as follows, with "project.prefix" being "BLT" by default:
 
 `"/(^${project.prefix}-[0-9]+(: )[^ ].{15,}\\.)|(Merge branch (.)+)/"`
 
-Note that this regex requires a period at the end of the commit message.
+Also note that this regex requires a period at the end of the commit message.
 
 # Resources
 

--- a/blt/blt.yml
+++ b/blt/blt.yml
@@ -1,69 +1,39 @@
-# This file contains your BLT configuration. For a list of all available
-# properties with current values run `blt config:dump`. Default values come
-# from vendor/acquia/blt/config/build.yml.
 project:
   machine_name: dojportal-blt
-  # Used for enforcing correct git commit msg syntax.
   prefix: BLT
   human_name: 'BLTed 10'
   profile:
     name: lightning
-  # This will be used as the local uri for all developers.
   local:
     protocol: http
     hostname: 'local.${project.machine_name}.com'
-# Configuration settings for new git repository.
 git:
   default_branch: master
   remotes:
     cloud: '${ACQUIA_CLOUD_REMOTE_GIT}'
 deploy:
-  # When manually deploying a tag, also tag the source repository.
   tag_source: true
 drush:
-  # You can set custom project aliases in drush/sites/*.site.yml.
   aliases:
-    # The remote environment from which the database will be pulled.
     remote: '${project.machine_name}.test'
-    # The local environment against which all local drush commands are run.
     local: self
-    # The drush alias against which all ci commands are run.
     ci: self
-    # The default drush alias to be used when no environment is specified.
   default_alias: '${drush.aliases.local}'
-# An array of modules to be enabled or uninstalled automatically in local, ci,
-# and deploy contexts.
 modules:
   local:
-    enable:
-      - dblog
-      - devel
-      - seckit
-      - views_ui
-    uninstall:
-      - acquia_connector
-      - shield
+    enable: [dblog, devel, seckit, views_ui]
+    uninstall: [acquia_connector, shield]
   ci:
     enable: {  }
-    uninstall:
-      - acquia_connector
-      - shield
+    uninstall: [acquia_connector, shield]
   dev:
-    enable:
-      - acquia_connector
-      - shield
+    enable: [acquia_connector, shield]
     uninstall: {  }
   test:
-    enable:
-      - acquia_connector
-      - shield
-    uninstall:
-      - devel
-      - views_ui
+    enable: [acquia_connector, shield]
+    uninstall: [devel, views_ui]
   prod:
-    enable:
-      - acquia_connector
-      - shield
-    uninstall:
-      - devel
-      - views_ui
+    enable: [acquia_connector, shield]
+    uninstall: [devel, views_ui]
+cloud:
+  appId: '${ACQUIA_APP_ID}'

--- a/drush/sites/dojportal-blt.site.yml
+++ b/drush/sites/dojportal-blt.site.yml
@@ -4,3 +4,36 @@ local:
     host: local.dojportal-blt.com
     user: vagrant
     ssh: { options: '-o StrictHostKeyChecking=no -o PasswordAuthentication=no -i $HOME/.vagrant.d/insecure_private_key' }
+
+# Application 'dojportal', environment 'dev'.
+dev:
+  root: /var/www/html/dojportal.dev/docroot
+  ac-site: dojportal
+  ac-env: dev
+  ac-realm: devcloud
+  uri: '${ACQUIA_DEV_URI}'
+  dev.livedev:
+    parent: '@dojportal.dev'
+    root: /mnt/gfs/dojportal.dev/livedev/docroot
+  host: '${ACQUIA_DEV_SSH_HOST}'
+  user: '${ACQUIA_DEV_DRUSH_USER}'
+  paths:
+    drush-script: drush9
+
+
+# Application 'dojportal', environment 'test'.
+test:
+  root: /var/www/html/dojportal.test/docroot
+  ac-site: dojportal
+  ac-env: test
+  ac-realm: devcloud
+  uri: '${ACQUIA_TEST_URI}'
+  test.livedev:
+    parent: '@dojportal.test'
+    root: /mnt/gfs/dojportal.test/livedev/docroot
+  host: '${ACQUIA_TEST_SSH_HOST}'
+  user: '${ACQUIA_TEST_DRUSH_USER}'
+  paths:
+    drush-script: drush9
+
+

--- a/drush/sites/dojportal-blt.site.yml
+++ b/drush/sites/dojportal-blt.site.yml
@@ -35,5 +35,3 @@ test:
   user: '${ACQUIA_TEST_DRUSH_USER}'
   paths:
     drush-script: drush9
-
-

--- a/example.set_environment_variables.sh
+++ b/example.set_environment_variables.sh
@@ -1,0 +1,13 @@
+export ACQUIA_CLOUD_REMOTE_GIT=""
+
+export ACQUIA_APP_ID=""
+
+# Drush settings for dev environment: drush/sites/dojportal-blt.site.yml
+export ACQUIA_DEV_SSH_HOST=""
+export ACQUIA_DEV_URI=""
+export ACQUIA_DEV_DRUSH_USER=""
+
+# Drush settings for test environment: drush/sites/dojportal-blt.site.yml
+export ACQUIA_TEST_SSH_HOST=""
+export ACQUIA_TEST_URI=""
+export ACQUIA_TEST_DRUSH_USER=""

--- a/example.set_environment_variables.sh
+++ b/example.set_environment_variables.sh
@@ -1,16 +1,12 @@
-# All of the configuration below should be available from
-# the Acquia Cloud platform. Please see the below resources:
-
-# Acquia Cloud drush config:
+# All of the configuration below should be available from the Acquia Cloud platform. Please see the below resources:
 #
+# Acquia Cloud drush config:
 # * https://docs.acquia.com/blt/developer/drush/
 #
 # "Obtaining your subscription’s application ID":
-#
 # * https://docs.acquia.com/acquia-cloud/manage/applications/#obtaining-your-subscription-s-application-id
 #
 # Acquia Cloud Remote git:
-#
 # * Available from the Acquia Cloud dashboard.
 
 export ACQUIA_CLOUD_REMOTE_GIT=""

--- a/example.set_environment_variables.sh
+++ b/example.set_environment_variables.sh
@@ -1,3 +1,18 @@
+# All of the configuration below should be available from
+# the Acquia Cloud platform. Please see the below resources:
+
+# Acquia Cloud drush config:
+#
+# * https://docs.acquia.com/blt/developer/drush/
+#
+# "Obtaining your subscription’s application ID":
+#
+# * https://docs.acquia.com/acquia-cloud/manage/applications/#obtaining-your-subscription-s-application-id
+#
+# Acquia Cloud Remote git:
+#
+# * Available from the Acquia Cloud dashboard.
+
 export ACQUIA_CLOUD_REMOTE_GIT=""
 
 export ACQUIA_APP_ID=""


### PR DESCRIPTION
# Notes

+ Followed steps documented here: https://docs.acquia.com/blt/developer/drush/; ran `blt recipes:aliases:init:acquia`.
+ Extracted ENV variables including SSH Hosts and URIs for development and test sites to a small script kept outside of source control. 
