### PR TITLE
Update README: Use `source` to set environment variables in shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Then, execute the file to set the environment variables locally:
 ```
 chmod +x set_environment_variables.sh
 
-./set_environment_variables.sh
+source set_environment_variables.sh
 ```
 
 Cheeck to see if your drush aliases are set up correctly:


### PR DESCRIPTION
# Notes 

+ `source script` runs the script in the current shell, whereas `./script` runs the script in a new shell