### PR TITLE
Handle drush site config naming more flexibly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 set_environment_variables.sh
 
 # Ignore drush config
-drush/sites/dojportal-blt.site.yml
+drush/sites/*.site.yml
 
 # Ignore subtheme files that ultimately generate CSS
 docroot/themes/custom/crt_portal_subtheme/node_modules


### PR DESCRIPTION
# Notes

+ This will allow us to name and call our drush sites config file however we want; this got a bit confusing for me because we had two different apps hosted on Acquia Cloud, each with a different name for its `.site.yml` config. Changing this will mean that either name will be kept out of source control. 