### PR TITLE
Add .gitattributes file to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# This file ensures consistent line-ending behavior for all users, regardless of their Git settings.
+
+# Git will always convert line endings to `LF` on checkout. You should use this for files that must keep LF endings, even on Windows.
+* text eol=lf


### PR DESCRIPTION
## What does this change?

Adds a `.gitattributes` file to enforce consistent line ending behavior for all users across Windows and Mac machines.

This should help remove a class of issues related to auto-conversion of line endings that we're running into as we debug @ilodidoj's local setup.

More: https://help.github.com/en/articles/configuring-git-to-handle-line-endings