### PR TITLE
This removes the flake8 errors, so we can add that validation

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1,8 +1,8 @@
-from django.forms import ModelForm, Select, ChoiceField, ModelMultipleChoiceField, CheckboxSelectMultiple, CheckboxInput, TypedChoiceField
+from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxSelectMultiple, CheckboxInput, TypedChoiceField
 
 from .widgets import UsaRadioSelect
 from .models import Report, ProtectedClass
-from .model_variables import *
+from .model_variables import EMPLOYER_SIZE_CHOICES, PUBLIC_OR_PRIVATE_SCHOOL_CHOICES, RESPONDENT_TYPE_CHOICES, HOW_MANY_CHOICES, RELATIONSHIP_CHOICES, PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, PUBLIC_OR_PRIVATE_FACILITY_CHOICES, PUBLIC_OR_PRIVATE_HEALTHCARE_CHOICES
 
 import logging
 
@@ -40,20 +40,19 @@ class WhatHappened(ModelForm):
 class Where(ModelForm):
     public_or_private_employer = TypedChoiceField(
         choices=PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
     public_or_private_facility = TypedChoiceField(
         choices=PUBLIC_OR_PRIVATE_FACILITY_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
     public_or_private_healthcare = TypedChoiceField(
         choices=PUBLIC_OR_PRIVATE_HEALTHCARE_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
     employer_size = TypedChoiceField(
         choices=EMPLOYER_SIZE_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
     public_or_private_school = TypedChoiceField(
         choices=PUBLIC_OR_PRIVATE_SCHOOL_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
-
+    )
 
     class Meta:
         model = Report
@@ -63,11 +62,10 @@ class Where(ModelForm):
         }
 
 
-
 class Who(ModelForm):
     respondent_type = TypedChoiceField(
         choices=RESPONDENT_TYPE_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
 
     class Meta:
         model = Report
@@ -80,7 +78,7 @@ class Who(ModelForm):
 class Details(ModelForm):
     how_many = TypedChoiceField(
         choices=HOW_MANY_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
 
     class Meta:
         model = Report
@@ -93,7 +91,7 @@ class Details(ModelForm):
 class Contact(ModelForm):
     relationship = TypedChoiceField(
         choices=RELATIONSHIP_CHOICES, empty_value=None, widget=UsaRadioSelect, required=False
-        )
+    )
 
     class Meta:
         model = Report

--- a/crt_portal/cts_forms/models.py
+++ b/crt_portal/cts_forms/models.py
@@ -1,9 +1,10 @@
+from datetime import datetime
+
 from django.db import models
 from django.utils import timezone
 
 from .model_variables import (
     PRIMARY_COMPLAINT_CHOICES,
-    PROTECTED_CLASS_CHOICES,
     PLACE_CHOICES,
     PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES,
     EMPLOYER_SIZE_CHOICES,
@@ -23,6 +24,7 @@ class InternalHistory(models.Model):
     note = models.CharField(max_length=500, null=False, blank=False,)
     create_date = models.DateTimeField(auto_now_add=True)
     # add author
+
 
 class ProtectedClass(models.Model):
     protected_class = models.CharField(max_length=100, null=True, blank=True,)

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -1,5 +1,6 @@
 from django.forms.widgets import ChoiceWidget
 
+
 class UsaRadioSelect(ChoiceWidget):
     input_type = 'radio'
     template_name = 'django/forms/widgets/radio.html'


### PR DESCRIPTION
[tech cleanup](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/126)

## What does this change?
lots of little tweaks to make the code flake8 compliant mosly import statements and spacing. 

## Screenshots (for front-end PR):

## Checklist:

_these will eventually be enforced by CircleCI; we need to set that up at the USDOJ org level_

+ [x] If front end or functionality change, run locally and check http://0.0.0.0:8000/report/.
+ [x] Tests pass locally: `docker-compose run web python /code/crt_portal/manage.py test cts_forms`.
+ [x] Running `flake8` in root returns no style errors.
+ [x] pa11y manual check against the `/report` page returns no errors.

## Notes for reviewer:
