### PR TITLE
We are ready for flake8 enforcement :)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: |
             pipenv run bandit -r crt_portal/
       - run:
-          name:
+          name: Run flake8 test for Python code style
           command: |
             pipenv run flake8
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,10 @@ jobs:
           name: Run bandit (Python security) tests
           command: |
             pipenv run bandit -r crt_portal/
-# # we are not ready for this
-#       - run:
-#           name:
-#           command: |
-#             pipenv run flake8
+      - run:
+          name:
+          command: |
+            pipenv run flake8
 
       - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
           path: /tmp/test-results


### PR DESCRIPTION
One more thing done for:[CI/CD deploy ticket](https://app.zenhub.com/workspaces/doj-crt-intake-scrum-board-5d03bf56c1c8a35d482eca0f/issues/18f/crt-portal/9)
## What does this change?
Activated the flake 8 enforcement

## Checklist:
https://circleci.com/gh/18F/crt-django/65

+ [ ] If front end or functionality change, run locally and check http://0.0.0.0:8000/report/.
+ [ ] Tests pass locally: `docker-compose run web python /code/crt_portal/manage.py test cts_forms`.
+ [ ] Running `flake8` in root returns no style errors.
+ [ ] pa11y manual check against the `/report` page returns no errors.

## Notes for reviewer:
