### PR TITLE
Add USWDS styling to CheckboxSelectMultiple widget

### DIFF
--- a/crt_portal/cts_forms/forms.py
+++ b/crt_portal/cts_forms/forms.py
@@ -1,6 +1,6 @@
-from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxSelectMultiple, CheckboxInput, TypedChoiceField
+from django.forms import ModelForm, ModelMultipleChoiceField, CheckboxInput, TypedChoiceField
 
-from .widgets import UsaRadioSelect
+from .widgets import UsaRadioSelect, UsaCheckboxSelectMultiple
 from .models import Report, ProtectedClass
 from .model_variables import EMPLOYER_SIZE_CHOICES, PUBLIC_OR_PRIVATE_SCHOOL_CHOICES, RESPONDENT_TYPE_CHOICES, HOW_MANY_CHOICES, RELATIONSHIP_CHOICES, PUBLIC_OR_PRIVATE_EMPLOYER_CHOICES, PUBLIC_OR_PRIVATE_FACILITY_CHOICES, PUBLIC_OR_PRIVATE_HEALTHCARE_CHOICES
 
@@ -18,7 +18,7 @@ class WhatHappened(ModelForm):
         fields = ['primary_complaint', 'protected_class']
         widgets = {
             'primary_complaint': UsaRadioSelect,
-            'protected_class': CheckboxSelectMultiple,
+            'protected_class': UsaCheckboxSelectMultiple,
         }
 
     # Overriding __init__ here allows us to provide initial

--- a/crt_portal/cts_forms/templates/forms/widgets/usa_checkbox_option.html
+++ b/crt_portal/cts_forms/templates/forms/widgets/usa_checkbox_option.html
@@ -1,0 +1,11 @@
+<div class="usa-checkbox">
+  <input type="checkbox"
+         name="{{ widget.name }}"
+         {% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}
+         class="usa-checkbox__input"
+         {% include "django/forms/widgets/attrs.html" %} />
+  <label class="usa-checkbox__label"
+         {% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>
+    {{ widget.label }}
+  </label>
+</div>

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -5,3 +5,29 @@ class UsaRadioSelect(ChoiceWidget):
     input_type = 'radio'
     template_name = 'django/forms/widgets/radio.html'
     option_template_name = '../templates/forms/widgets/usa_radio_option.html'
+
+
+class UsaCheckboxSelectMultiple(ChoiceWidget):
+    allow_multiple_selected = True
+    input_type = 'checkbox'
+    template_name = 'django/forms/widgets/checkbox_select.html'
+    option_template_name = '../templates/forms/widgets/usa_checkbox_option.html'
+
+    def use_required_attribute(self, initial):
+        # Don't use the 'required' attribute because browser validation would
+        # require all checkboxes to be checked instead of at least one.
+        return False
+
+    def value_omitted_from_data(self, data, files, name):
+        # HTML checkboxes don't appear in POST data if not checked, so it's
+        # never known if the value is actually omitted.
+        return False
+
+    def id_for_label(self, id_, index=None):
+        """"
+        Don't include for="field_0" in <label> because clicking such a label
+        would toggle the first checkbox.
+        """
+        if index is None:
+            return ''
+        return super().id_for_label(id_, index)

--- a/crt_portal/cts_forms/widgets.py
+++ b/crt_portal/cts_forms/widgets.py
@@ -7,6 +7,8 @@ class UsaRadioSelect(ChoiceWidget):
     option_template_name = '../templates/forms/widgets/usa_radio_option.html'
 
 
+# Overrides Django CheckboxSelectMultiple:
+# https://docs.djangoproject.com/en/2.2/ref/forms/widgets/#checkboxselectmultiple
 class UsaCheckboxSelectMultiple(ChoiceWidget):
     allow_multiple_selected = True
     input_type = 'checkbox'


### PR DESCRIPTION
## What does this change?

+ Adds USWDS styling classes to checkboxes generated by Django form wizard. 

## Screenshot (for front-end PR):

<img width="267" alt="checkboxes-uswds" src="https://user-images.githubusercontent.com/3209501/64434024-48ac7400-d085-11e9-8a75-b708f7ccea28.png">


## Checklist:

_these will eventually be enforced by CircleCI; we need to set that up at the USDOJ org level_

+ [x] If front end or functionality change, run locally and check http://0.0.0.0:8000/report/.
+ [x] pa11y manual check against the `/report` page returns no errors.

## Notes for reviewer:

+ Our last USWDS-styling PR reverted some functionality that we wanted to keep (HTML validation messages on required radio buttons), so let's double-check to make sure this PR doesn't revert any functionality. I checked and didn't find anything, but a second pair of eyes never hurts!