### PR TITLE
Use python 3.7.4 buildpack

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.2
+python-3.7.4


### PR DESCRIPTION
## What does this change?

+ Bump python version!
+ 🤞resolve issue with missing buildpack:

```
**ERROR** Could not install python: no match found for 3.7.2 in [2.7.15 2.7.16 3.4.9 3.4.10 3.5.6 3.5.7 3.6.8 3.6.9 3.7.3 3.7.4]
Failed to compile droplet: Failed to run all supply scripts: exit status 14
```